### PR TITLE
fix/change 'event' reference for consistency

### DIFF
--- a/ajax-form.html
+++ b/ajax-form.html
@@ -114,8 +114,8 @@ that all of your HTML imports are concatenated into one file.__
          * the `detail` property of the event passed to your handler.
          *
          *     form.addEventListener('invalid',
-         *         function(e) {
-         *             e.detail.forEach(function(badEl) {
+         *         function(event) {
+         *             event.detail.forEach(function(badEl) {
          *                 // handle invalid element
          *             });
          *          }
@@ -131,7 +131,7 @@ that all of your HTML imports are concatenated into one file.__
          * on the event's `detail` property.
          *
          *     form.addEventListener('submitted',
-         *         function(e) {
+         *         function(event) {
          *             if (event.detail.status > 299) {
          *                 // submit has failed
          *             }


### PR DESCRIPTION
The [documentation for event listeners](http://garstasio.github.io/ajax-form/components/ajax-form/#ajax-form.events) has some inconsistencies/errors. Namely:
- the listener's callback event is sometimes referred to as `e` and sometimes referred to as `event` between the different examples
- the listener's callback event is referred to improperly for 'submitted' (argument setup as `e`, then immediately referred to as `event` within the same function)

To remedy these problems, I made all listener events `event`.
