### PR TITLE
Add support to the input form as an array name

### DIFF
--- a/ajax-form.js
+++ b/ajax-form.js
@@ -59,7 +59,7 @@
                     selectedItem = coreMenu && coreMenu.selectedItem;
 
                 if (selectedItem) {
-                    data[customElement.getAttribute('name')] = selectedItem.label || selectedItem.textContent;
+                    data.push({key: customElement.getAttribute('name'), value: selectedItem.label || selectedItem.textContent});
                     return true;
                 }
 
@@ -74,7 +74,7 @@
                 var fileInputName = element.getAttribute('name');
 
                 if (element.files.length) {
-                    data[fileInputName] = arrayOf(element.files);
+                    data.push({key: fileInputName, value: arrayOf(element.files)});
                 }
 
                 return true;
@@ -83,20 +83,19 @@
 
         maybeParseGenericCustomElement = function(customElement, data) {
             if (customElement.tagName.indexOf('-') >= 0 && customElement.value != null) {
-                data[customElement.getAttribute('name')] = customElement.value;
+                data.push({key: customElement.getAttribute('name'), value: customElement.value});
                 return true;
             }
         },
 
         parseCustomElements = function(form, parseFileInputs) {
-            var data = {};
+            var data = [];
 
             arrayOf(form.querySelectorAll('*[name]')).forEach(function(el) {
                 (parseFileInputs && maybeParseFileInput(el, data)) ||
                 maybeParseCoreDropdownMenu(el, data) ||
                 maybeParseGenericCustomElement(el, data);
             });
-
             return data;
         },
 
@@ -144,14 +143,13 @@
                     var key = formElement.name,
                         val = parseElementValue(formElement);
 
-                    if (key && val) {
+                    if (key && val)
                         formObj.push({key: key, value: val});
-                    }
                 }
             });
 
-            Object.keys(customElementsData).forEach(function(fieldName) {
-                formObj.push({key: fieldName, value: customElementsData[fieldName]});
+            customElementsData.forEach(function(customElement) {
+                formObj.push({key: customElement.key, value: customElement.value});
             });
 
             return formObj;
@@ -326,7 +324,7 @@
             var queryParams = [];
 
             params.forEach(function(param) {
-                var val = param.value,
+                var val = param.value;
                 key = encodeURIComponent(param.key);
 
                 if (val && Object.prototype.toString.call(val) === '[object Array]') {

--- a/ajax-form.js
+++ b/ajax-form.js
@@ -125,10 +125,10 @@
         /**
          * Parse an `HTMLFormElement` into key value pairs
          * @param HTMLFormElement form
-         * @return Object key, value pairs representing the html form
+         * @return Collection of object key, value pairs representing the html form
          */
         parseForm = function(form, parseFileInputs) {
-            var formObj = {},
+            var formObj = [],
                 formElements = form.querySelectorAll('input'),
                 customElementsData = parseCustomElements(form, parseFileInputs);
 
@@ -145,13 +145,13 @@
                         val = parseElementValue(formElement);
 
                     if (key && val) {
-                        formObj[key] = val;
+                        formObj.push({key: key, value: val});
                     }
                 }
             });
 
             Object.keys(customElementsData).forEach(function(fieldName) {
-                formObj[fieldName] = customElementsData[fieldName];
+                formObj.push({key: fieldName, value: customElementsData[fieldName]});
             });
 
             return formObj;
@@ -170,8 +170,8 @@
                 ['submit', 'reset', 'button', 'image'].indexOf(elementType) !== -1) {
                 // do nothing for these button types
             }
-            else if (elementType === 'radio') {
-                elementValue = parseRadioElementValue(element);
+            else if (elementType === 'radio' || elementType === 'checkbox') {
+                elementValue = parseRadioOrCheckboxElementValue(element);
             } else {
                 elementValue = element.value;
             }
@@ -186,7 +186,7 @@
          * @param HTMLRadioElement element
          * @return mixed The element's value
          */
-        parseRadioElementValue = function(element) {
+        parseRadioOrCheckboxElementValue = function(element) {
             var value;
             if (element.checked === true) {
                 value = element.value;
@@ -251,6 +251,7 @@
         },
 
         sendJsonEncodedForm = function(ajaxForm, data) {
+
             sendRequest({
                 body: JSON.stringify(data),
                 contentType: getEnctype(ajaxForm),
@@ -324,9 +325,9 @@
         toQueryString = function(params) {
             var queryParams = [];
 
-            Object.keys(params).forEach(function(key) {
-                var val = params[key];
-                key = encodeURIComponent(key);
+            params.forEach(function(param) {
+                var val = param.value,
+                key = encodeURIComponent(param.key);
 
                 if (val && Object.prototype.toString.call(val) === '[object Array]') {
                     val.forEach(function(valInArray) {


### PR DESCRIPTION
I tried using the code below, but it only send the last checkbox (not checked).
```html
<input type="checkbox" name="checkbox1[]" value="foo" checked>
<input type="checkbox" name="checkbox1[]" value="bar" checked>
<input type="checkbox" name="checkbox1[]" value="fizz">
```
Also, It isn't working for the input field as array format names. This link can help to understand: http://stackoverflow.com/questions/4709926/how-can-i-use-the-array-format-input-field-names-in-my-html-form-that-posts-to-p

I done some changes in the ajax-form.js to support it, but be will need update the current tests. I have not sure if this is better way. Make sense?