### PR TITLE
Modify parse logic to check for a `files` attribute and parse it

### DIFF
--- a/ajax-form.js
+++ b/ajax-form.js
@@ -81,10 +81,16 @@
             }
         },
 
-        maybeParseGenericCustomElement = function(customElement, data) {
-            if (customElement.tagName.indexOf('-') >= 0 && customElement.value != null) {
+        maybeParseGenericCustomElement = function(customElement, data, parseFileInputs) {
+            if (customElement.tagName.indexOf('-') >= 0 ) {
+              if (customElement.value != null) {
                 data[customElement.getAttribute('name')] = customElement.value;
                 return true;
+              }
+              else if (parseFileInputs && customElement.files && customElement.files.length) {
+                 data[customElement.getAttribute('name')] = arrayOf(customElement.files);
+                 return true;
+              }
             }
         },
 
@@ -92,9 +98,8 @@
             var data = {};
 
             arrayOf(form.querySelectorAll('*[name]')).forEach(function(el) {
-                (parseFileInputs && maybeParseFileInput(el, data)) ||
                 maybeParseCoreDropdownMenu(el, data) ||
-                maybeParseGenericCustomElement(el, data);
+                maybeParseGenericCustomElement(el, data, parseFileInputs);
             });
 
             return data;


### PR DESCRIPTION

As discussed in issue #51 

**Change Summary**
- Modified logic in `maybeParseGenericCustomElement` to check for a `files` attribute on custom elements instead of deferring to the `maybeParseFileInput` function.
- Modified the anonymous iterator for form parsing to remove explicit calling of `maybeParseFileInput` and to pass the `parseFileInputs` flag along instead of predicating behavior based on it.
- Left the old <file-input> specific logic as it was used in other places (made minimum viable change). This might want to be refactored.

**Testing Performed**
- Manual functional testing using `<image-input>` as discussed in referenced issue (passed)
- Ran the test suite (passed)