### PR TITLE
Add support for more elements in paper-dropdown-menu

### DIFF
--- a/ajax-form.js
+++ b/ajax-form.js
@@ -103,8 +103,8 @@
         maybeParseCoreDropdownMenu = function(customElement, data) {
             if (customElement.tagName.toLowerCase() === 'core-dropdown-menu' ||
                 customElement.tagName.toLowerCase() === 'paper-dropdown-menu') {
-                var coreMenu = customElement.querySelector('core-menu'),
-                    selectedItem = coreMenu && coreMenu.selectedItem;
+                var menuContainer = customElement.querySelector('core-menu,paper-menu,paper-list-box'),
+                    selectedItem = menuContainer && menuContainer.selectedItem;
 
                 if (selectedItem) {
                     processFormValue(customElement.getAttribute('name'), selectedItem.label || selectedItem.textContent, data);


### PR DESCRIPTION
core-menu is not available in Polymer 1.0 and paper-menu and paper-list-box elements are currently skipped over when getting the selectedItem from core-dropdown-menu and paper-dropdown-menu.

This adds the new elements to the querySelector for the dropdown menus.