### PR TITLE
Allow an in-progress submission to be aborted

### DIFF
--- a/ajax-form.js
+++ b/ajax-form.js
@@ -378,6 +378,8 @@
             };
 
             xhr.send(options.body);
+
+            fire(options.form, 'abortable', function() { xhr.abort(); });
         },
 
         sendUrlencodedForm = function(ajaxForm, formData) {


### PR DESCRIPTION
A user can listen for the `abortable` event and call the function in the event's details if the in-progress XHR should be aborted.

I would have preferred to implement this as a method on the form itself but it would have meant adding state to the element and since there was no precedent for that I decided this was cleaner.